### PR TITLE
Pass "readonly" along to `OctoKitIssue`

### DIFF
--- a/api/octokit.js
+++ b/api/octokit.js
@@ -49,7 +49,7 @@ class OctoKit {
             numRequests++;
             const page = pageResponse.data;
             utils_1.safeLog(`Page ${++pageNum}: ${page.map(({ number }) => number).join(' ')}`);
-            yield page.map((issue) => new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue)));
+            yield page.map((issue) => new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue), this.options));
         }
     }
     async createIssue(owner, repo, title, body) {

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -59,7 +59,8 @@ export class OctoKit implements GitHub {
 			const page: Array<Octokit.SearchIssuesAndPullRequestsResponseItemsItem> = pageResponse.data
 			safeLog(`Page ${++pageNum}: ${page.map(({ number }) => number).join(' ')}`)
 			yield page.map(
-				(issue) => new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue)),
+				(issue) =>
+					new OctoKitIssue(this.token, this.params, this.octokitIssueToIssue(issue), this.options),
 			)
 		}
 	}


### PR DESCRIPTION
The "readonly" flag is meant for doing a dry run of an action, correct? I found that it was not being passed along to the issue, so it was not as "dry" a run as expected.