### PR TITLE
Fix inaccurate log during needs-more-info-closer

### DIFF
--- a/needs-more-info-closer/NeedsMoreInfoCloser.js
+++ b/needs-more-info-closer/NeedsMoreInfoCloser.js
@@ -37,7 +37,7 @@ class NeedsMoreInfoCloser {
                         this.additionalTeam.includes(lastComment.author.name) ||
                         (await issue.hasWriteAccess(lastComment.author))) {
                         if (lastComment) {
-                            utils_1.safeLog(`Last comment on ${hydrated.number} by rando. Closing.`);
+                            utils_1.safeLog(`Last comment on ${hydrated.number} by team. Closing.`);
                         }
                         else {
                             utils_1.safeLog(`No comments on ${hydrated.number}. Closing.`);

--- a/needs-more-info-closer/NeedsMoreInfoCloser.ts
+++ b/needs-more-info-closer/NeedsMoreInfoCloser.ts
@@ -45,7 +45,7 @@ export class NeedsMoreInfoCloser {
 						(await issue.hasWriteAccess(lastComment.author))
 					) {
 						if (lastComment) {
-							safeLog(`Last comment on ${hydrated.number} by rando. Closing.`)
+							safeLog(`Last comment on ${hydrated.number} by team. Closing.`)
 						} else {
 							safeLog(`No comments on ${hydrated.number}. Closing.`)
 						}


### PR DESCRIPTION
It closes when the last comment is by the _team_, not a _rando_, right?