### PR TITLE
Fix some bugs in `stale-closer`

### DIFF
--- a/feature-request/FeatureRequest.js
+++ b/feature-request/FeatureRequest.js
@@ -60,9 +60,7 @@ class FeatureRequestQueryer {
                 }
             }
             if (!state.initTimestamp) {
-                if (this.config.comments.init) {
-                    await new FeatureRequestOnMilestone(issue, this.config.comments.init, this.config.milestones.candidateID).run();
-                }
+                await new FeatureRequestOnMilestone(issue, this.config.comments.init, this.config.milestones.candidateID).run();
             }
             else if (!state.warnTimestamp) {
                 if (this.daysSince(state.initTimestamp) >

--- a/feature-request/FeatureRequest.ts
+++ b/feature-request/FeatureRequest.ts
@@ -18,7 +18,7 @@ export type FeatureRequestConfig = {
 	upvotesRequired: number
 	numCommentsOverride: number
 	labelsToExclude: string[]
-	comments: { init?: string; warn: string; accept?: string; reject: string; rejectLabel?: string }
+	comments: { init: string; warn: string; accept?: string; reject: string; rejectLabel?: string }
 	delays: { warn: number; close: number }
 }
 
@@ -78,13 +78,11 @@ export class FeatureRequestQueryer {
 				}
 			}
 			if (!state.initTimestamp) {
-				if (this.config.comments.init) {
-					await new FeatureRequestOnMilestone(
-						issue,
-						this.config.comments.init,
-						this.config.milestones.candidateID,
-					).run()
-				}
+				await new FeatureRequestOnMilestone(
+					issue,
+					this.config.comments.init,
+					this.config.milestones.candidateID,
+				).run()
 			} else if (!state.warnTimestamp) {
 				if (
 					this.daysSince(state.initTimestamp) >

--- a/feature-request/index.ts
+++ b/feature-request/index.ts
@@ -57,7 +57,7 @@ class FeatureRequest extends Action {
 	async onMilestoned(github: OctoKitIssue) {
 		await new FeatureRequestOnMilestone(
 			github,
-			config.comments.init!,
+			config.comments.init,
 			config.milestones.candidateID,
 		).run()
 	}

--- a/stale-closer/action.yml
+++ b/stale-closer/action.yml
@@ -21,6 +21,9 @@ inputs:
     required: true
   labelsToExclude:
     description: A comma-separated list of labels to exclude from processing
+  initComment:
+    description: Comment when an issue is introduced to the backlog milestone
+    required: true
   warnComment:
     description: Comment when an issue is nearing automatic closure
     required: true

--- a/stale-closer/index.js
+++ b/stale-closer/index.js
@@ -17,7 +17,7 @@ const config = {
     numCommentsOverride: +utils_1.getRequiredInput('numCommentsOverride'),
     labelsToExclude: (utils_1.getInput('labelsToExclude') || '').split(',').filter((l) => !!l),
     comments: {
-        init: utils_1.getInput('initComment'),
+        init: utils_1.getRequiredInput('initComment'),
         warn: utils_1.getRequiredInput('warnComment'),
         reject: utils_1.getRequiredInput('rejectComment'),
         rejectLabel: utils_1.getInput('rejectLabel'),
@@ -39,6 +39,9 @@ class StaleCloser extends Action_1.Action {
         if (label === config.featureRequestLabel) {
             await new FeatureRequest_1.FeatureRequestOnLabel(github, +utils_1.getRequiredInput('milestoneDelaySeconds'), config.milestones.candidateID, config.featureRequestLabel).run();
         }
+    }
+    async onMilestoned(github) {
+        await new FeatureRequest_1.FeatureRequestOnMilestone(github, config.comments.init, config.milestones.candidateID).run();
     }
 }
 new StaleCloser().run(); // eslint-disable-line

--- a/stale-closer/index.ts
+++ b/stale-closer/index.ts
@@ -8,6 +8,7 @@ import { getInput, getRequiredInput } from '../common/utils'
 import {
 	FeatureRequestConfig,
 	FeatureRequestOnLabel,
+	FeatureRequestOnMilestone,
 	FeatureRequestQueryer,
 } from '../feature-request/FeatureRequest'
 import { Action } from '../common/Action'
@@ -22,7 +23,7 @@ const config: FeatureRequestConfig = {
 	numCommentsOverride: +getRequiredInput('numCommentsOverride'),
 	labelsToExclude: ((getInput('labelsToExclude') as string) || '').split(',').filter((l) => !!l),
 	comments: {
-		init: getInput('initComment'),
+		init: getRequiredInput('initComment'),
 		warn: getRequiredInput('warnComment'),
 		reject: getRequiredInput('rejectComment'),
 		rejectLabel: getInput('rejectLabel'),
@@ -49,6 +50,14 @@ class StaleCloser extends Action {
 				config.featureRequestLabel,
 			).run()
 		}
+	}
+
+	async onMilestoned(github: OctoKitIssue) {
+		await new FeatureRequestOnMilestone(
+			github,
+			config.comments.init,
+			config.milestones.candidateID,
+		).run()
 	}
 }
 


### PR DESCRIPTION
This PR fixes two bugs with the `stale-closer` bot.

- The lack of an `initComment` meant it fell into the `if (!state.initTimestamp)` block, and then never did anything
- It should still have the `onMilestoned` trigger