### PR TITLE
Makes octokit milestone aware

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -88,12 +88,22 @@ export interface Issue {
 	isPr: boolean
 	numComments: number
 	reactions: Reactions
-	milestoneId: number | null
+	milestone: Milestone | null
 	assignee?: string
 	assignees: string[]
 	createdAt: number
 	updatedAt: number
 	closedAt?: number
+}
+export interface Milestone {
+	milestoneId: number
+	title: string
+	description: string
+	numClosedIssues: number
+	numOpenIssues: number
+	dueOn: string
+	createdAt: string
+	closedAt: string
 }
 export interface Query {
 	q: string

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -63,7 +63,7 @@ class OctoKit {
             await this.octokit.issues.create({ owner, repo, title, body });
     }
     octokitIssueToIssue(issue) {
-        var _a, _b, _c, _d, _e, _f, _g, _h, _j;
+        var _a, _b, _c, _d, _e, _f, _g;
         return {
             author: { name: issue.user.login, isGitHubApp: issue.user.type === 'Bot' },
             body: issue.body,
@@ -77,10 +77,22 @@ class OctoKit {
             reactions: issue.reactions,
             assignee: (_c = (_b = issue.assignee) === null || _b === void 0 ? void 0 : _b.login) !== null && _c !== void 0 ? _c : (_e = (_d = issue.assignees) === null || _d === void 0 ? void 0 : _d[0]) === null || _e === void 0 ? void 0 : _e.login,
             assignees: (_g = (_f = issue.assignees) === null || _f === void 0 ? void 0 : _f.map((assignee) => assignee.login)) !== null && _g !== void 0 ? _g : [],
-            milestoneId: (_j = (_h = issue.milestone) === null || _h === void 0 ? void 0 : _h.number) !== null && _j !== void 0 ? _j : null,
+            milestone: issue.milestone ? this.octokitMilestoneToMilestone(issue.milestone) : null,
             createdAt: +new Date(issue.created_at),
             updatedAt: +new Date(issue.updated_at),
             closedAt: issue.closed_at ? +new Date(issue.closed_at) : undefined,
+        };
+    }
+    octokitMilestoneToMilestone(milestone) {
+        return {
+            title: milestone.title,
+            closedAt: milestone.closed_at,
+            dueOn: milestone.due_on,
+            milestoneId: milestone.id,
+            createdAt: milestone.created_at,
+            description: milestone.description,
+            numClosedIssues: milestone.closed_issues,
+            numOpenIssues: milestone.open_issues,
         };
     }
     async hasWriteAccess(user) {

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -7,7 +7,7 @@ import { GitHub as GitHubAPI } from '@actions/github'
 import { Octokit } from '@octokit/rest'
 import { exec } from 'child_process'
 import { safeLog } from '../common/utils'
-import { Comment, GitHub, GitHubIssue, Issue, Query, User } from './api'
+import { Comment, GitHub, GitHubIssue, Issue, Milestone, Query, User } from './api'
 
 let numRequests = 0
 export const getNumRequests = () => numRequests
@@ -91,10 +91,23 @@ export class OctoKit implements GitHub {
 			assignee: issue.assignee?.login ?? (issue as Octokit.IssuesGetResponse).assignees?.[0]?.login,
 			assignees:
 				(issue as Octokit.IssuesGetResponse).assignees?.map((assignee) => assignee.login) ?? [],
-			milestoneId: issue.milestone?.number ?? null,
+			milestone: issue.milestone ? this.octokitMilestoneToMilestone(issue.milestone) : null,
 			createdAt: +new Date(issue.created_at),
 			updatedAt: +new Date(issue.updated_at),
 			closedAt: issue.closed_at ? +new Date(issue.closed_at as unknown as string) : undefined,
+		}
+	}
+
+	protected octokitMilestoneToMilestone(milestone: Octokit.IssuesGetResponseMilestone): Milestone {
+		return {
+			title: milestone.title,
+			closedAt: milestone.closed_at,
+			dueOn: milestone.due_on,
+			milestoneId: milestone.id,
+			createdAt: milestone.created_at,
+			description: milestone.description,
+			numClosedIssues: milestone.closed_issues,
+			numOpenIssues: milestone.open_issues,
 		}
 	}
 

--- a/api/testbed.js
+++ b/api/testbed.js
@@ -90,7 +90,21 @@ class TestbedIssue extends Testbed {
         this.issueConfig.issue.assignee = undefined;
     }
     async setMilestone(milestoneId) {
-        this.issueConfig.issue.milestoneId = milestoneId;
+        if (this.issueConfig.issue.milestone) {
+            this.issueConfig.issue.milestone.milestoneId = milestoneId;
+        }
+        else {
+            this.issueConfig.issue.milestone = {
+                milestoneId,
+                title: '',
+                description: '',
+                dueOn: '',
+                closedAt: '',
+                createdAt: '',
+                numClosedIssues: 0,
+                numOpenIssues: 0,
+            };
+        }
     }
     async getIssue() {
         const labels = [...this.issueConfig.labels];

--- a/api/testbed.ts
+++ b/api/testbed.ts
@@ -130,7 +130,20 @@ export class TestbedIssue extends Testbed implements GitHubIssue {
 	}
 
 	async setMilestone(milestoneId: number): Promise<void> {
-		this.issueConfig.issue.milestoneId = milestoneId
+		if (this.issueConfig.issue.milestone) {
+			this.issueConfig.issue.milestone.milestoneId = milestoneId
+		} else {
+			this.issueConfig.issue.milestone = {
+				milestoneId,
+				title: '',
+				description: '',
+				dueOn: '',
+				closedAt: '',
+				createdAt: '',
+				numClosedIssues: 0,
+				numOpenIssues: 0,
+			}
+		}
 	}
 
 	async getIssue(): Promise<Issue> {

--- a/feature-request/FeatureRequest.js
+++ b/feature-request/FeatureRequest.js
@@ -17,13 +17,14 @@ class FeatureRequestQueryer {
         this.config = config;
     }
     async run() {
+        var _a;
         let query = `is:open is:issue milestone:"${this.config.milestones.candidateName}" label:"${this.config.featureRequestLabel}"`;
         query += this.config.labelsToExclude.map((l) => `-label:"${l}"`).join(' ');
         for await (const page of this.github.query({ q: query })) {
             for (const issue of page) {
                 const issueData = await issue.getIssue();
                 if (issueData.open &&
-                    issueData.milestoneId === this.config.milestones.candidateID &&
+                    ((_a = issueData.milestone) === null || _a === void 0 ? void 0 : _a.milestoneId) === this.config.milestones.candidateID &&
                     issueData.labels.includes(this.config.featureRequestLabel) &&
                     !issueData.labels.some((issueLabel) => this.config.labelsToExclude.some((excludeLabel) => issueLabel === excludeLabel))) {
                     await this.actOn(issue);
@@ -99,10 +100,11 @@ class FeatureRequestOnLabel {
         this.label = label;
     }
     async run() {
+        var _a;
         await new Promise((resolve) => setTimeout(resolve, this.delay * 1000));
         const issue = await this.github.getIssue();
         if (!issue.open ||
-            issue.milestoneId ||
+            ((_a = issue.milestone) === null || _a === void 0 ? void 0 : _a.milestoneId) ||
             !issue.labels.includes(this.label) ||
             (await this.github.hasWriteAccess(issue.author))) {
             return;
@@ -118,8 +120,9 @@ class FeatureRequestOnMilestone {
         this.milestone = milestone;
     }
     async run() {
+        var _a;
         const issue = await this.github.getIssue();
-        if (issue.open && issue.milestoneId === this.milestone) {
+        if (issue.open && ((_a = issue.milestone) === null || _a === void 0 ? void 0 : _a.milestoneId) === this.milestone) {
             await this.github.postComment(exports.CREATE_MARKER + '\n' + this.comment);
         }
     }

--- a/feature-request/FeatureRequest.ts
+++ b/feature-request/FeatureRequest.ts
@@ -33,7 +33,7 @@ export class FeatureRequestQueryer {
 				const issueData = await issue.getIssue()
 				if (
 					issueData.open &&
-					issueData.milestoneId === this.config.milestones.candidateID &&
+					issueData.milestone?.milestoneId === this.config.milestones.candidateID &&
 					issueData.labels.includes(this.config.featureRequestLabel) &&
 					!issueData.labels.some((issueLabel) =>
 						this.config.labelsToExclude.some((excludeLabel) => issueLabel === excludeLabel),
@@ -128,7 +128,7 @@ export class FeatureRequestOnLabel {
 
 		if (
 			!issue.open ||
-			issue.milestoneId ||
+			issue.milestone?.milestoneId ||
 			!issue.labels.includes(this.label) ||
 			(await this.github.hasWriteAccess(issue.author))
 		) {
@@ -144,7 +144,7 @@ export class FeatureRequestOnMilestone {
 
 	async run(): Promise<void> {
 		const issue = await this.github.getIssue()
-		if (issue.open && issue.milestoneId === this.milestone) {
+		if (issue.open && issue.milestone?.milestoneId === this.milestone) {
 			await this.github.postComment(CREATE_MARKER + '\n' + this.comment)
 		}
 	}


### PR DESCRIPTION
As part of #24 the GitHub api surfaces we use must be aware of what a milestone is. This adds some basic milestone properties and a milestone object to the issue object.