### PR TITLE
Assign milestone on close with commit

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -19,6 +19,12 @@ export interface GitHub {
 	createIssue(owner: string, repo: string, title: string, body: string): Promise<void>;
 
 	releaseContainsCommit(release: string, commit: string): Promise<'yes' | 'no' | 'unknown'>;
+
+	/**
+	 * Returns what we think the current milestone for the repo is based on the due on date.
+	 * @returns The milestone id if one is found, else undefined
+	 */
+	getCurrentRepoMilestone(): Promise<number | undefined>;
 }
 
 export interface GitHubIssue extends GitHub {
@@ -33,11 +39,6 @@ export interface GitHubIssue extends GitHub {
 	unlockIssue(): Promise<void>;
 
 	setMilestone(milestoneId: number): Promise<void>;
-	/**
-	 * Returns what we think the current milestone for the repo is based on the due on date.
-	 * @returns The milestone id if one is found, else undefined
-	 */
-	getCurrentRepoMilestone(): Promise<number | undefined>;
 
 	addLabel(label: string): Promise<void>;
 	removeLabel(label: string): Promise<void>;

--- a/api/api.ts
+++ b/api/api.ts
@@ -33,6 +33,11 @@ export interface GitHubIssue extends GitHub {
 	unlockIssue(): Promise<void>;
 
 	setMilestone(milestoneId: number): Promise<void>;
+	/**
+	 * Returns what we think the current milestone for the repo is based on the due on date.
+	 * @returns The milestone id if one is found, else undefined
+	 */
+	getCurrentRepoMilestone(): Promise<number | undefined>;
 
 	addLabel(label: string): Promise<void>;
 	removeLabel(label: string): Promise<void>;

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -181,6 +181,23 @@ class OctoKit {
             }
         }));
     }
+    async getCurrentRepoMilestone() {
+        (0, utils_1.safeLog)(`Getting repo milestone for`);
+        // Fetch all milestones open for this repo
+        const allMilestones = (await this.octokit.issues.listMilestonesForRepo({
+            owner: this.params.owner,
+            repo: this.params.repo,
+            state: 'open',
+            sort: 'due_on',
+            direction: 'asc',
+        })).data;
+        const currentDate = new Date();
+        const possibleMilestones = allMilestones.filter((milestone) => new Date(milestone.due_on) > currentDate && currentDate > new Date(milestone.created_at));
+        if (possibleMilestones.length === 0) {
+            return undefined;
+        }
+        return possibleMilestones[0].id;
+    }
     async dispatch(title) {
         (0, utils_1.safeLog)('Dispatching ' + title);
         if (!this.options.readonly)
@@ -277,23 +294,6 @@ class OctoKitIssue extends OctoKit {
                 issue_number: this.issueData.number,
                 milestone: milestoneId,
             });
-    }
-    async getCurrentRepoMilestone() {
-        (0, utils_1.safeLog)(`Getting repo milestone for ${this.issueData.number}`);
-        // Fetch all milestones open for this repo
-        const allMilestones = (await this.octokit.issues.listMilestonesForRepo({
-            owner: this.params.owner,
-            repo: this.params.repo,
-            state: 'open',
-            sort: 'due_on',
-            direction: 'asc',
-        })).data;
-        const currentDate = new Date();
-        const possibleMilestones = allMilestones.filter((milestone) => new Date(milestone.due_on) > currentDate && currentDate > new Date(milestone.created_at));
-        if (possibleMilestones.length === 0) {
-            return undefined;
-        }
-        return possibleMilestones[0].id;
     }
     async *getComments(last) {
         (0, utils_1.safeLog)('Fetching comments for ' + this.issueData.number);

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -278,6 +278,23 @@ class OctoKitIssue extends OctoKit {
                 milestone: milestoneId,
             });
     }
+    async getCurrentRepoMilestone() {
+        (0, utils_1.safeLog)(`Getting repo milestone for ${this.issueData.number}`);
+        // Fetch all milestones open for this repo
+        const allMilestones = (await this.octokit.issues.listMilestonesForRepo({
+            owner: this.params.owner,
+            repo: this.params.repo,
+            state: 'open',
+            sort: 'due_on',
+            direction: 'asc',
+        })).data;
+        const currentDate = new Date();
+        const possibleMilestones = allMilestones.filter((milestone) => new Date(milestone.due_on) > currentDate && currentDate > new Date(milestone.created_at));
+        if (possibleMilestones.length === 0) {
+            return undefined;
+        }
+        return possibleMilestones[0].id;
+    }
     async *getComments(last) {
         (0, utils_1.safeLog)('Fetching comments for ' + this.issueData.number);
         const response = this.octokit.paginate.iterator(this.octokit.issues.listComments.endpoint.merge({

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -182,7 +182,7 @@ class OctoKit {
         }));
     }
     async getCurrentRepoMilestone() {
-        (0, utils_1.safeLog)(`Getting repo milestone for`);
+        (0, utils_1.safeLog)(`Getting repo milestone for ${this.params.owner}/${this.params.repo}`);
         // Fetch all milestones open for this repo
         const allMilestones = (await this.octokit.issues.listMilestonesForRepo({
             owner: this.params.owner,

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -200,6 +200,29 @@ export class OctoKit implements GitHub {
 		);
 	}
 
+	async getCurrentRepoMilestone(): Promise<number | undefined> {
+		safeLog(`Getting repo milestone for`);
+		// Fetch all milestones open for this repo
+		const allMilestones = (
+			await this.octokit.issues.listMilestonesForRepo({
+				owner: this.params.owner,
+				repo: this.params.repo,
+				state: 'open',
+				sort: 'due_on',
+				direction: 'asc',
+			})
+		).data;
+		const currentDate = new Date();
+		const possibleMilestones = allMilestones.filter(
+			(milestone) =>
+				new Date(milestone.due_on) > currentDate && currentDate > new Date(milestone.created_at),
+		);
+		if (possibleMilestones.length === 0) {
+			return undefined;
+		}
+		return possibleMilestones[0].id;
+	}
+
 	async dispatch(title: string): Promise<void> {
 		safeLog('Dispatching ' + title);
 		if (!this.options.readonly)
@@ -311,29 +334,6 @@ export class OctoKitIssue extends OctoKit implements GitHubIssue {
 				issue_number: this.issueData.number,
 				milestone: milestoneId,
 			});
-	}
-
-	async getCurrentRepoMilestone(): Promise<number | undefined> {
-		safeLog(`Getting repo milestone for ${this.issueData.number}`);
-		// Fetch all milestones open for this repo
-		const allMilestones = (
-			await this.octokit.issues.listMilestonesForRepo({
-				owner: this.params.owner,
-				repo: this.params.repo,
-				state: 'open',
-				sort: 'due_on',
-				direction: 'asc',
-			})
-		).data;
-		const currentDate = new Date();
-		const possibleMilestones = allMilestones.filter(
-			(milestone) =>
-				new Date(milestone.due_on) > currentDate && currentDate > new Date(milestone.created_at),
-		);
-		if (possibleMilestones.length === 0) {
-			return undefined;
-		}
-		return possibleMilestones[0].id;
 	}
 
 	async *getComments(last?: boolean): AsyncIterableIterator<Comment[]> {

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -313,6 +313,29 @@ export class OctoKitIssue extends OctoKit implements GitHubIssue {
 			});
 	}
 
+	async getCurrentRepoMilestone(): Promise<number | undefined> {
+		safeLog(`Getting repo milestone for ${this.issueData.number}`);
+		// Fetch all milestones open for this repo
+		const allMilestones = (
+			await this.octokit.issues.listMilestonesForRepo({
+				owner: this.params.owner,
+				repo: this.params.repo,
+				state: 'open',
+				sort: 'due_on',
+				direction: 'asc',
+			})
+		).data;
+		const currentDate = new Date();
+		const possibleMilestones = allMilestones.filter(
+			(milestone) =>
+				new Date(milestone.due_on) > currentDate && currentDate > new Date(milestone.created_at),
+		);
+		if (possibleMilestones.length === 0) {
+			return undefined;
+		}
+		return possibleMilestones[0].id;
+	}
+
 	async *getComments(last?: boolean): AsyncIterableIterator<Comment[]> {
 		safeLog('Fetching comments for ' + this.issueData.number);
 

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -201,7 +201,7 @@ export class OctoKit implements GitHub {
 	}
 
 	async getCurrentRepoMilestone(): Promise<number | undefined> {
-		safeLog(`Getting repo milestone for`);
+		safeLog(`Getting repo milestone for ${this.params.owner}/${this.params.repo}`);
 		// Fetch all milestones open for this repo
 		const allMilestones = (
 			await this.octokit.issues.listMilestonesForRepo({

--- a/api/testbed.js
+++ b/api/testbed.js
@@ -107,6 +107,12 @@ class TestbedIssue extends Testbed {
             };
         }
     }
+    async getCurrentRepoMilestone() {
+        if (this.issueConfig.issue.milestone) {
+            return this.issueConfig.issue.milestone.milestoneId;
+        }
+        return undefined;
+    }
     async getIssue() {
         const labels = [...this.issueConfig.labels];
         return { ...this.issueConfig.issue, labels };

--- a/api/testbed.js
+++ b/api/testbed.js
@@ -48,6 +48,10 @@ class Testbed {
     async dispatch(title) {
         (0, utils_1.safeLog)('dispatching for', title);
     }
+    async getCurrentRepoMilestone() {
+        // pass
+        return undefined;
+    }
 }
 exports.Testbed = Testbed;
 class TestbedIssue extends Testbed {
@@ -106,12 +110,6 @@ class TestbedIssue extends Testbed {
                 state: 'open',
             };
         }
-    }
-    async getCurrentRepoMilestone() {
-        if (this.issueConfig.issue.milestone) {
-            return this.issueConfig.issue.milestone.milestoneId;
-        }
-        return undefined;
     }
     async getIssue() {
         const labels = [...this.issueConfig.labels];

--- a/api/testbed.ts
+++ b/api/testbed.ts
@@ -147,6 +147,13 @@ export class TestbedIssue extends Testbed implements GitHubIssue {
 		}
 	}
 
+	async getCurrentRepoMilestone(): Promise<number | undefined> {
+		if (this.issueConfig.issue.milestone) {
+			return this.issueConfig.issue.milestone.milestoneId;
+		}
+		return undefined;
+	}
+
 	async getIssue(): Promise<Issue> {
 		const labels = [...this.issueConfig.labels];
 		return { ...this.issueConfig.issue, labels };

--- a/api/testbed.ts
+++ b/api/testbed.ts
@@ -72,6 +72,11 @@ export class Testbed implements GitHub {
 	async dispatch(title: string): Promise<void> {
 		safeLog('dispatching for', title);
 	}
+
+	async getCurrentRepoMilestone(): Promise<number | undefined> {
+		// pass
+		return undefined;
+	}
 }
 
 type TestbedIssueConfig = {
@@ -145,13 +150,6 @@ export class TestbedIssue extends Testbed implements GitHubIssue {
 				state: 'open',
 			};
 		}
-	}
-
-	async getCurrentRepoMilestone(): Promise<number | undefined> {
-		if (this.issueConfig.issue.milestone) {
-			return this.issueConfig.issue.milestone.milestoneId;
-		}
-		return undefined;
 	}
 
 	async getIssue(): Promise<Issue> {

--- a/release-pipeline/ReleasePipeline.js
+++ b/release-pipeline/ReleasePipeline.js
@@ -81,6 +81,13 @@ const enrollIssue = async (issue, notYetReleasedLabel) => {
     const closingHash = (_a = (await issue.getClosingInfo())) === null || _a === void 0 ? void 0 : _a.hash;
     if (closingHash) {
         await issue.addLabel(notYetReleasedLabel);
+        // Get the milestone linked to the current release and set it if the issue doesn't have one
+        const releaseMilestone = (await issue.getIssue()).milestone
+            ? undefined
+            : await issue.getCurrentRepoMilestone();
+        if (releaseMilestone !== undefined) {
+            await issue.setMilestone(releaseMilestone);
+        }
         await (0, telemetry_1.trackEvent)(issue, 'insiders-released:unreleased');
     }
     else {

--- a/release-pipeline/ReleasePipeline.ts
+++ b/release-pipeline/ReleasePipeline.ts
@@ -84,6 +84,13 @@ export const enrollIssue = async (issue: GitHubIssue, notYetReleasedLabel: strin
 	const closingHash = (await issue.getClosingInfo())?.hash;
 	if (closingHash) {
 		await issue.addLabel(notYetReleasedLabel);
+		// Get the milestone linked to the current release and set it if the issue doesn't have one
+		const releaseMilestone = (await issue.getIssue()).milestone
+			? undefined
+			: await issue.getCurrentRepoMilestone();
+		if (releaseMilestone !== undefined) {
+			await issue.setMilestone(releaseMilestone);
+		}
 		await trackEvent(issue, 'insiders-released:unreleased');
 	} else {
 		await trackEvent(issue, 'insiders-released:skipped');

--- a/release-pipeline/index.ts
+++ b/release-pipeline/index.ts
@@ -33,4 +33,4 @@ class ReleasePipelineAction extends Action {
 	}
 }
 
-new ReleasePipelineAction().run() // eslint-disable-line
+new ReleasePipelineAction().run(); // eslint-disable-line


### PR DESCRIPTION
Fixes #24 

This implements a best guess milestone assignment based on the milestone due dates in the repository. I only assign a milestone based on the `enroll` function as it seems like that is triggered first and doing it on `update` as well wasn't necessary.

