### PR TITLE
Fix word wrapping

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -113,12 +113,11 @@ class CodeReviewChat extends Chatter {
         this.options = options;
         this.pr = options.payload.pr;
     }
-    async postMessage(message, blocks) {
+    async postMessage(message) {
         const { client, channel } = await this.getChat();
         await client.chat.postMessage({
             text: message,
             channel,
-            blocks,
             link_names: true,
         });
     }
@@ -176,18 +175,10 @@ class CodeReviewChat extends Chatter {
                 : ` (in ${this.options.payload.repo_full_name}):`;
             const githubUrl = this.pr.url;
             const vscodeDevUrl = this.pr.url.replace('https://', 'https://insiders.vscode.dev/');
-            const blocks = [];
-            // The message is a singular markdown blocks
-            blocks.push({
-                type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: `*${cleanTitle}* by _${this.pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`,
-                },
-            });
-            const message = `New Pull Request from ${this.pr.owner}`;
+            // Nicely formatted chat message
+            const message = `*${cleanTitle}* by _${this.pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`;
             (0, utils_1.safeLog)(message);
-            await this.postMessage(message, blocks);
+            await this.postMessage(message);
         })());
         await Promise.all(tasks);
     }

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Octokit } from '@octokit/rest';
-import { KnownBlock, WebClient } from '@slack/web-api';
+import { WebClient } from '@slack/web-api';
 import { GitHubIssue } from '../api/api';
 import { safeLog } from '../common/utils';
 
@@ -164,13 +164,12 @@ export class CodeReviewChat extends Chatter {
 		this.pr = options.payload.pr;
 	}
 
-	private async postMessage(message: string, blocks?: KnownBlock[]) {
+	private async postMessage(message: string) {
 		const { client, channel } = await this.getChat();
 
 		await client.chat.postMessage({
 			text: message,
 			channel,
-			blocks,
 			link_names: true,
 		});
 	}
@@ -241,19 +240,11 @@ export class CodeReviewChat extends Chatter {
 
 				const githubUrl = this.pr.url;
 				const vscodeDevUrl = this.pr.url.replace('https://', 'https://insiders.vscode.dev/');
-				const blocks: KnownBlock[] = [];
-				// The message is a singular markdown blocks
-				blocks.push({
-					type: 'section',
-					text: {
-						type: 'mrkdwn',
-						text: `*${cleanTitle}* by _${this.pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`,
-					},
-				});
 
-				const message = `New Pull Request from ${this.pr.owner}`;
+				// Nicely formatted chat message
+				const message = `*${cleanTitle}* by _${this.pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`;
 				safeLog(message);
-				await this.postMessage(message, blocks);
+				await this.postMessage(message);
 			})(),
 		);
 


### PR DESCRIPTION
Slack's block kit messages automatically wrap after ~85 characters to allow for better alignment of things like buttons. Since we have removed the buttons lets just go back to plain text messages to avoid wrapping