### PR TITLE
Support posting bots in code review chat

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -128,12 +128,13 @@ class CodeReviewChat extends Chatter {
         }
         const data = await this.issue.getIssue();
         const author = data.author;
-        if (!(await this.issue.hasWriteAccess(author))) {
+        // Author must have write access to the repo or be a bot
+        if (!(await this.issue.hasWriteAccess(author)) && !author.isGitHubApp) {
             (0, utils_1.safeLog)('Issue author not team member, ignoring');
             return;
         }
         const tasks = [];
-        if (!data.assignee) {
+        if (!data.assignee && !author.isGitHubApp) {
             tasks.push(this.issue.addAssignee(author.name));
         }
         tasks.push((async () => {

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -182,13 +182,14 @@ export class CodeReviewChat extends Chatter {
 
 		const data = await this.issue.getIssue();
 		const author = data.author;
-		if (!(await this.issue.hasWriteAccess(author))) {
+		// Author must have write access to the repo or be a bot
+		if (!(await this.issue.hasWriteAccess(author)) && !author.isGitHubApp) {
 			safeLog('Issue author not team member, ignoring');
 			return;
 		}
 		const tasks = [];
 
-		if (!data.assignee) {
+		if (!data.assignee && !author.isGitHubApp) {
 			tasks.push(this.issue.addAssignee(author.name));
 		}
 


### PR DESCRIPTION
Auto generated PRs from bots will also be fielded to the code review chat. This is necessary for the vscode-loc workflow.