### PR TITLE
Assign on-testplan to validated test plan issues

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 export interface GitHub {
+	repoOwner: string;
+	repoName: string;
+
 	query(query: Query): AsyncIterableIterator<GitHubIssue[]>;
 
 	hasWriteAccess(user: User): Promise<boolean>;

--- a/api/octokit.js
+++ b/api/octokit.js
@@ -20,6 +20,8 @@ class OctoKit {
         this.mockLabels = new Set();
         this.writeAccessCache = {};
         this._octokit = (0, github_1.getOctokit)(token);
+        this.repoName = params.repo;
+        this.repoOwner = params.owner;
     }
     get octokit() {
         numRequests++;

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -23,12 +23,17 @@ export class OctoKit implements GitHub {
 	// when in readonly mode, record labels just-created so at to not throw unneccesary errors
 	protected mockLabels: Set<string> = new Set();
 
+	public readonly repoName: string;
+	public readonly repoOwner: string;
+
 	constructor(
 		protected token: string,
 		protected params: { repo: string; owner: string },
 		protected options: { readonly: boolean } = { readonly: false },
 	) {
 		this._octokit = getOctokit(token);
+		this.repoName = params.repo;
+		this.repoOwner = params.owner;
 	}
 
 	getIssueByNumber(number: number) {

--- a/api/testbed.js
+++ b/api/testbed.js
@@ -9,6 +9,8 @@ const utils_1 = require("../common/utils");
 class Testbed {
     constructor(config) {
         var _a, _b, _c, _d, _e;
+        this.repoName = 'test-repo';
+        this.repoOwner = 'test-owner';
         this.config = {
             globalLabels: (_a = config === null || config === void 0 ? void 0 : config.globalLabels) !== null && _a !== void 0 ? _a : [],
             configs: (_b = config === null || config === void 0 ? void 0 : config.configs) !== null && _b !== void 0 ? _b : {},

--- a/api/testbed.ts
+++ b/api/testbed.ts
@@ -19,6 +19,9 @@ export type TestbedConstructorArgs = Partial<TestbedConfig>;
 export class Testbed implements GitHub {
 	public config: TestbedConfig;
 
+	public readonly repoName: string = 'test-repo';
+	public readonly repoOwner: string = 'test-owner';
+
 	constructor(config?: TestbedConstructorArgs) {
 		this.config = {
 			globalLabels: config?.globalLabels ?? [],

--- a/test-plan-item-validator/TestPlanItemValidator.test.ts
+++ b/test-plan-item-validator/TestPlanItemValidator.test.ts
@@ -36,7 +36,7 @@ This new API allows extensions to contribute to an environment variable collecti
 describe('TestPlanItemValidator', () => {
 	it('does nothing for valid test plan items', async () => {
 		const testbed = new TestbedIssue({}, { issue: { body: validTestPlanItem }, labels: ['tpi'] });
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
 
 		const comments: Comment[] = [];
 		for await (const page of testbed.getComments()) {
@@ -48,7 +48,7 @@ describe('TestPlanItemValidator', () => {
 
 	it('does nothing for non test plan items', async () => {
 		const testbed = new TestbedIssue({}, { issue: { body: invalidTestPlanItem } });
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
 
 		const comments: Comment[] = [];
 		for await (const page of testbed.getComments()) {
@@ -59,7 +59,7 @@ describe('TestPlanItemValidator', () => {
 
 	it('adds comment for invalid test plan items', async () => {
 		const testbed = new TestbedIssue({}, { issue: { body: invalidTestPlanItem }, labels: ['tpi'] });
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
 
 		const comments: Comment[] = [];
 		for await (const page of testbed.getComments()) {
@@ -74,9 +74,9 @@ describe('TestPlanItemValidator', () => {
 	it('only adds one comment even on multiple runs', async () => {
 		const testbed = new TestbedIssue({}, { issue: { body: invalidTestPlanItem }, labels: ['tpi'] });
 
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
 
 		const comments: Comment[] = [];
 		for await (const page of testbed.getComments()) {
@@ -88,7 +88,7 @@ describe('TestPlanItemValidator', () => {
 
 	it('cleans up after itself once issue has been fixed', async () => {
 		const testbed = new TestbedIssue({}, { issue: { body: invalidTestPlanItem }, labels: ['tpi'] });
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
 
 		const comments: Comment[] = [];
 		for await (const page of testbed.getComments()) {
@@ -99,7 +99,7 @@ describe('TestPlanItemValidator', () => {
 		expect(testbed.issueConfig.labels.includes('tpi')).false;
 
 		testbed.issueConfig.issue.body = validTestPlanItem;
-		await new TestPlanItemValidator(testbed, 'tpi', 'invalid-tpi', 'plz fix').run();
+		await new TestPlanItemValidator(testbed, '', '', 'tpi', 'invalid-tpi', 'plz fix').run();
 		const newComments: Comment[] = [];
 		for await (const page of testbed.getComments()) {
 			newComments.push(...page);

--- a/test-plan-item-validator/TestPlanitemValidator.js
+++ b/test-plan-item-validator/TestPlanitemValidator.js
@@ -51,6 +51,10 @@ class TestPlanItemValidator {
         try {
             const testPlan = (0, validator_1.parseTestPlanItem)(issue.body, issue.author.name);
             if (testPlan.issueRefs.length) {
+                // In the case of testing we don't test this due to the complexity of the API.
+                if (!this.token) {
+                    return;
+                }
                 const octokit = new rest_1.Octokit({ auth: this.token });
                 for (const referencedIssueNum of testPlan.issueRefs) {
                     await octokit.issues.addLabels({

--- a/test-plan-item-validator/TestPlanitemValidator.ts
+++ b/test-plan-item-validator/TestPlanitemValidator.ts
@@ -61,6 +61,10 @@ export class TestPlanItemValidator {
 		try {
 			const testPlan = parseTestPlanItem(issue.body, issue.author.name);
 			if (testPlan.issueRefs.length) {
+				// In the case of testing we don't test this due to the complexity of the API.
+				if (!this.token) {
+					return;
+				}
 				const octokit = new Octokit({ auth: this.token });
 				for (const referencedIssueNum of testPlan.issueRefs) {
 					await octokit.issues.addLabels({

--- a/test-plan-item-validator/action.yml
+++ b/test-plan-item-validator/action.yml
@@ -7,6 +7,10 @@ inputs:
   label:
     description: The label that signifies an item is a testplan item and should be checked
     required: true
+  refLabel:
+    description: The label to apply to referenced issues
+    default: 'on-testplan'
+    required: true
   invalidLabel:
     description: The label to add when a test plan item is invalid
     required: true

--- a/test-plan-item-validator/index.js
+++ b/test-plan-item-validator/index.js
@@ -13,7 +13,7 @@ class TestPlanItemValidatorAction extends Action_1.Action {
         this.id = 'TestPlanItemValidator';
     }
     async runValidation(issue) {
-        await new TestPlanitemValidator_1.TestPlanItemValidator(issue, (0, utils_1.getRequiredInput)('label'), (0, utils_1.getRequiredInput)('invalidLabel'), (0, utils_1.getRequiredInput)('comment')).run();
+        await new TestPlanitemValidator_1.TestPlanItemValidator(issue, (0, utils_1.getRequiredInput)('token'), (0, utils_1.getRequiredInput)('refLabel'), (0, utils_1.getRequiredInput)('label'), (0, utils_1.getRequiredInput)('invalidLabel'), (0, utils_1.getRequiredInput)('comment')).run();
     }
     async onLabeled(issue) {
         await this.runValidation(issue);

--- a/test-plan-item-validator/index.ts
+++ b/test-plan-item-validator/index.ts
@@ -14,6 +14,8 @@ class TestPlanItemValidatorAction extends Action {
 	async runValidation(issue: OctoKitIssue) {
 		await new TestPlanItemValidator(
 			issue,
+			getRequiredInput('token'),
+			getRequiredInput('refLabel'),
 			getRequiredInput('label'),
 			getRequiredInput('invalidLabel'),
 			getRequiredInput('comment'),


### PR DESCRIPTION
Fixes #94.


I decided not to do the verification needed part of the issue as I believe that should have a bit more author intervention and there isn't really an easy way to determine when we would run an automated task like that anyways. This just adds on-testplan to issues referenced in a test plan after our validator validates that the testplan is of valid structure.