### PR TITLE
Disable posting release PRs to codereview channel

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -126,6 +126,11 @@ class CodeReviewChat extends Chatter {
             (0, utils_1.safeLog)('PR is draft, ignoring');
             return;
         }
+        // TODO @lramos15 possibly make this configurable
+        if (this.pr.baseBranchName.startsWith('release')) {
+            (0, utils_1.safeLog)('PR is on a release branch, ignoring');
+            return;
+        }
         const data = await this.issue.getIssue();
         const author = data.author;
         // Author must have write access to the repo or be a bot

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -17,6 +17,14 @@ interface PR {
 	url: string;
 	owner: string;
 	draft: boolean;
+	/**
+	 * The branch you're merging into i.e main
+	 */
+	baseBranchName: string;
+	/**
+	 * The branch the PR is created from i.e. feature/foo
+	 */
+	headBranchName: string;
 	title: string;
 }
 
@@ -177,6 +185,12 @@ export class CodeReviewChat extends Chatter {
 	async run() {
 		if (this.pr.draft) {
 			safeLog('PR is draft, ignoring');
+			return;
+		}
+
+		// TODO @lramos15 possibly make this configurable
+		if (this.pr.baseBranchName.startsWith('release')) {
+			safeLog('PR is on a release branch, ignoring');
 			return;
 		}
 

--- a/code-review-chat/index.js
+++ b/code-review-chat/index.js
@@ -24,7 +24,7 @@ class CodeReviewChatAction extends Action_1.Action {
         await new CodeReviewChat_1.CodeReviewChatDeleter(slackToken, elevatedUserToken, channel, payload.pull_request.html_url).run();
     }
     async onOpened(issue, payload) {
-        var _a;
+        var _a, _b, _c;
         if (!payload.pull_request || !payload.repository) {
             throw Error('expected payload to contain pull request and repository');
         }
@@ -48,6 +48,8 @@ class CodeReviewChatAction extends Action_1.Action {
                     url: payload.pull_request.html_url || '',
                     owner: payload.pull_request.user.login,
                     draft: payload.pull_request.draft || false,
+                    baseBranchName: (_b = payload.pull_request.base.ref) !== null && _b !== void 0 ? _b : '',
+                    headBranchName: (_c = payload.pull_request.head.ref) !== null && _c !== void 0 ? _c : '',
                     title: payload.pull_request.title,
                 },
             },

--- a/code-review-chat/index.ts
+++ b/code-review-chat/index.ts
@@ -58,6 +58,8 @@ class CodeReviewChatAction extends Action {
 					url: payload.pull_request.html_url || '',
 					owner: payload.pull_request.user.login,
 					draft: payload.pull_request.draft || false,
+					baseBranchName: payload.pull_request.base.ref ?? '',
+					headBranchName: payload.pull_request.head.ref ?? '',
 					title: payload.pull_request.title,
 				},
 			},


### PR DESCRIPTION
This skips posting PRs made against the release branch into the codereview channel