### PR TITLE
Don't use invalid as_user argument

### DIFF
--- a/build-chat/BuildChat.js
+++ b/build-chat/BuildChat.js
@@ -176,9 +176,7 @@ async function buildComplete(octokit, owner, repo, runId, options) {
             text: `${name}
 Result: ${build.data.conclusion} | Repository: ${owner}/${repo} | Branch: ${build.data.head_branch} | Authors: ${githubToSlackUsers(githubAccountMap, build.authors, build.degraded).sort().join(', ') ||
                 `None (rebuild)`}
-Build: ${build.buildHtmlUrl}
-Create Issue: ${createIssueLink}
-Changes: ${build.changesHtmlUrl}`,
+<${build.buildHtmlUrl}|Build> | <Create Issue|${createIssueLink}> | <${build.changesHtmlUrl}|Changes>`,
             slackAuthors: build.authors.map((a) => { var _a; return (_a = githubAccountMap[a]) === null || _a === void 0 ? void 0 : _a.slack; }).filter((a) => !!a),
         };
     });

--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -94,13 +94,12 @@ class CodeReviewChatDeleter extends Chatter {
                     await client.chat.delete({
                         channel,
                         ts: message.ts,
-                        as_user: false,
                     });
                 }
             }
         }
         catch (e) {
-            (0, utils_1.safeLog)('error deleting message, probably posted by some human');
+            (0, utils_1.safeLog)(`Error deleting message: ${e.message}`);
         }
     }
 }

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -155,12 +155,11 @@ export class CodeReviewChatDeleter extends Chatter {
 					await client.chat.delete({
 						channel,
 						ts: message.ts,
-						as_user: false,
 					});
 				}
 			}
-		} catch (e) {
-			safeLog('error deleting message, probably posted by some human');
+		} catch (e: any) {
+			safeLog(`Error deleting message: ${e.message}`);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #115

Depsite the [slack docs](https://api.slack.com/methods/chat.delete) having no mention of this parameter being invalid it appears that it causes an error to be thrown and the messages not being deleted when it is provided. This argument is needed when using the elevated client but not the non elevated one. I also pass forward the slack error to help further describe what the issue is