### PR TITLE
Check from draft via API 

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -121,7 +121,13 @@ class CodeReviewChat extends Chatter {
         });
     }
     async run() {
-        if (this.pr.draft) {
+        // Must request the PR again from the octokit api as it may have changed since creation
+        const prFromApi = (await this.octokit.pulls.get({
+            pull_number: this.pr.number,
+            owner: this.options.payload.owner,
+            repo: this.options.payload.repo,
+        })).data;
+        if (prFromApi.draft) {
             (0, utils_1.safeLog)('PR is draft, ignoring');
             return;
         }

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -182,7 +182,15 @@ export class CodeReviewChat extends Chatter {
 	}
 
 	async run() {
-		if (this.pr.draft) {
+		// Must request the PR again from the octokit api as it may have changed since creation
+		const prFromApi = (
+			await this.octokit.pulls.get({
+				pull_number: this.pr.number,
+				owner: this.options.payload.owner,
+				repo: this.options.payload.repo,
+			})
+		).data;
+		if (prFromApi.draft) {
 			safeLog('PR is draft, ignoring');
 			return;
 		}


### PR DESCRIPTION
Fixes #114.

While not a direct duplicate check which maybe we still want this should fix the many cases of draft PRs being incorrectly posted