### PR TITLE
Fail the action even with a caught error

### DIFF
--- a/common/Action.js
+++ b/common/Action.js
@@ -102,6 +102,8 @@ class Action {
             }
             catch {
                 (0, utils_1.safeLog)((err === null || err === void 0 ? void 0 : err.stack) || (err === null || err === void 0 ? void 0 : err.message) || String(e));
+                // Always fail the action even if we don't properly log it to the issue
+                (0, core_1.setFailed)(err.message);
             }
         }
         await this.trackMetric({ name: 'octokit_request_count', value: (0, octokit_1.getNumRequests)() });

--- a/common/Action.ts
+++ b/common/Action.ts
@@ -115,6 +115,8 @@ export abstract class Action {
 				await this.error(err);
 			} catch {
 				safeLog(err?.stack || err?.message || String(e));
+				// Always fail the action even if we don't properly log it to the issue
+				setFailed(err.message);
 			}
 		}
 


### PR DESCRIPTION
Caught errors should still fail the action to not give a false positive pass