### PR TITLE
Re-disable auto assigning labels

### DIFF
--- a/classifier-deep/apply/apply-labels/index.js
+++ b/classifier-deep/apply/apply-labels/index.js
@@ -103,9 +103,7 @@ class ApplyLabels extends Action_1.Action {
                     await issue.postComment(`confidence for label ${category}: ${confidence}. ${confident ? 'does' : 'does not'} meet threshold`);
                 }
                 if (confident) {
-                    (0, utils_1.safeLog)(`adding label ${category} to issue ${issueData.number}`);
-                    // Actually assign the label
-                    await issue.addLabel(category);
+                    (0, utils_1.safeLog)(`assigning person based on label ${category} for issue ${issueData.number}`);
                     // Assign the issue to the proper person based on the label that was assigned
                     // This is configurable in the per repo config
                     const labelConfig = (_a = config.labels) === null || _a === void 0 ? void 0 : _a[category];

--- a/classifier-deep/apply/apply-labels/index.ts
+++ b/classifier-deep/apply/apply-labels/index.ts
@@ -137,9 +137,7 @@ class ApplyLabels extends Action {
 				}
 
 				if (confident) {
-					safeLog(`adding label ${category} to issue ${issueData.number}`);
-					// Actually assign the label
-					await issue.addLabel(category);
+					safeLog(`assigning person based on label ${category} for issue ${issueData.number}`);
 
 					// Assign the issue to the proper person based on the label that was assigned
 					// This is configurable in the per repo config


### PR DESCRIPTION
Auto assigning of labels doesn' seem to be favored by all, so disabling to avoid any productivity loss