### PR TITLE
Ignore events that don't affect code-review

### DIFF
--- a/code-review-chat/index.js
+++ b/code-review-chat/index.js
@@ -100,6 +100,11 @@ class CodeReviewChatAction extends Action_1.Action {
             case 'converted_to_draft':
                 await this.onConvertedToDraft(octokitIssue, payload);
                 break;
+            // These are part of the webhook chain, let's no-op but allow the CI to pass
+            case 'dismissed':
+            case 'synchronize':
+            case 'reopened':
+                break;
             default:
                 throw Error(`Unknown action: ${action}`);
         }

--- a/code-review-chat/index.ts
+++ b/code-review-chat/index.ts
@@ -127,6 +127,11 @@ class CodeReviewChatAction extends Action {
 			case 'converted_to_draft':
 				await this.onConvertedToDraft(octokitIssue, payload);
 				break;
+			// These are part of the webhook chain, let's no-op but allow the CI to pass
+			case 'dismissed':
+			case 'synchronize':
+			case 'reopened':
+				break;
 			default:
 				throw Error(`Unknown action: ${action}`);
 		}


### PR DESCRIPTION
Ignores some events that were added as part of the same CI run which this takes place in, but does not affect this step