### PR TITLE
Remove Python workflow to delete unrecognizable labels

### DIFF
--- a/python-issue-labels/action.yml
+++ b/python-issue-labels/action.yml
@@ -9,9 +9,6 @@ inputs:
     description: 'Triagers to add to the issue'
     required: false
     default: '["karrtikr","karthiknadig","paulacamargo25","eleanorjboyd"]'
-  repo_labels:
-    description: 'Keywords that indicate a question is being asked'
-    required: true
 
 runs:
   using: 'node16'

--- a/python-issue-labels/index.js
+++ b/python-issue-labels/index.js
@@ -58,16 +58,6 @@ class IssueLabels extends Action_1.Action {
             issue_number: github_1.context.issue.number,
             assignees: assigneesToRemove,
         });
-        const knownLabels = JSON.parse((0, utils_1.getRequiredInput)('repo_labels'));
-        for (const label of labels) {
-            if (!knownLabels.includes(label)) {
-                await github.rest.issues.deleteLabel({
-                    owner: github_1.context.repo.owner,
-                    repo: github_1.context.repo.repo,
-                    name: label,
-                });
-            }
-        }
     }
 }
 new IssueLabels().run(); // eslint-disable-line

--- a/python-issue-labels/index.ts
+++ b/python-issue-labels/index.ts
@@ -68,16 +68,6 @@ class IssueLabels extends Action {
 			issue_number: context.issue.number,
 			assignees: assigneesToRemove,
 		});
-		const knownLabels = JSON.parse(getRequiredInput('repo_labels'));
-		for (const label of labels) {
-			if (!knownLabels.includes(label)) {
-				await github.rest.issues.deleteLabel({
-					owner: context.repo.owner,
-					repo: context.repo.repo,
-					name: label,
-				});
-			}
-		}
 	}
 }
 


### PR DESCRIPTION
We added this to remove unrecognizable label after transferring but we probably don't need that anymore.

It leads to deleting labels even when we don't want to: https://github.com/microsoft/vscode-python/issues/22008, cc/ @luabud