### PR TITLE
Don't call conversation.list

### DIFF
--- a/code-review-chat/action.yml
+++ b/code-review-chat/action.yml
@@ -12,7 +12,7 @@ inputs:
   slack_user_token:
     description: 'Elevated user token for actions requiring admin'
     required: false
-  notification_channel:
+  notification_channel_id:
     description: 'Which channel to send notifications to. Defaults to none.'
     required: true
   slack_bot_name:

--- a/code-review-chat/index.js
+++ b/code-review-chat/index.js
@@ -13,7 +13,7 @@ const vscodeTools_1 = require("../api/vscodeTools");
 const slackToken = (0, utils_1.getRequiredInput)('slack_token');
 const elevatedUserToken = (0, utils_1.getInput)('slack_user_token');
 const auth = (0, utils_1.getRequiredInput)('token');
-const channel = (0, utils_1.getRequiredInput)('notification_channel');
+const channelId = (0, utils_1.getRequiredInput)('notification_channel_id');
 const apiConfig = {
     tenantId: (0, utils_1.getRequiredInput)('tenantId'),
     clientId: (0, utils_1.getRequiredInput)('clientId'),
@@ -29,7 +29,7 @@ class CodeReviewChatAction extends Action_1.Action {
         if (!payload.pull_request || !payload.repository || !payload.pull_request.html_url) {
             throw Error('expected payload to contain pull request url');
         }
-        await new CodeReviewChat_1.CodeReviewChatDeleter(slackToken, elevatedUserToken, channel, payload.pull_request.html_url).run();
+        await new CodeReviewChat_1.CodeReviewChatDeleter(slackToken, elevatedUserToken, channelId, payload.pull_request.html_url).run();
     }
     async onClosed(_issue, payload) {
         await this.closedOrDraftHandler(_issue, payload);
@@ -52,7 +52,7 @@ class CodeReviewChatAction extends Action_1.Action {
         }
         return new CodeReviewChat_1.CodeReviewChat(github, new vscodeTools_1.VSCodeToolsAPIManager(apiConfig), issue, {
             slackToken,
-            codereviewChannel: channel,
+            codereviewChannelId: channelId,
             payload: {
                 owner: payload.repository.owner.login,
                 repo: payload.repository.name,

--- a/code-review-chat/index.ts
+++ b/code-review-chat/index.ts
@@ -20,7 +20,7 @@ import { VSCodeToolsAPIManager } from '../api/vscodeTools';
 const slackToken = getRequiredInput('slack_token');
 const elevatedUserToken = getInput('slack_user_token');
 const auth = getRequiredInput('token');
-const channel = getRequiredInput('notification_channel');
+const channelId = getRequiredInput('notification_channel_id');
 const apiConfig = {
 	tenantId: getRequiredInput('tenantId'),
 	clientId: getRequiredInput('clientId'),
@@ -38,7 +38,7 @@ class CodeReviewChatAction extends Action {
 		await new CodeReviewChatDeleter(
 			slackToken,
 			elevatedUserToken,
-			channel,
+			channelId,
 			payload.pull_request.html_url,
 		).run();
 	}
@@ -81,7 +81,7 @@ class CodeReviewChatAction extends Action {
 			issue,
 			{
 				slackToken,
-				codereviewChannel: channel,
+				codereviewChannelId: channelId,
 				payload: {
 					owner: payload.repository.owner.login,
 					repo: payload.repository.name,


### PR DESCRIPTION
`conversation.list` is a decently rate limited and expensive API call that was only introduced so that you could define a slack channel by name rather than by ID. This is causing us to get rate limited on occasion which will lead to the message failing to send all together. Ref: https://github.com/microsoft/vscode-engineering/issues/411


Let's just switch to using the channel ID directly