### PR TITLE
Allow locker config limiting to only issues or prs

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ inputs:
 ```
 
 ### Locker
-Lock issues and PRs that have been closed and not updated for some time.
+Lock issues and/or PRs that have been closed and not updated for some time.
 
 ```yml
 inputs:
@@ -327,6 +327,8 @@ inputs:
     description: items with this label will not be automatically locked, until they also have the until label
   labelUntil:
     description: items with this will not automatically locked, even if they have the ignoreLabelUntil label
+  typeIs:
+    description: either 'issue' or 'pr' to limit the query to only those types
 ```
 
 ### Needs More Info Closer

--- a/locker/Locker.test.ts
+++ b/locker/Locker.test.ts
@@ -82,4 +82,70 @@ describe('Locker', () => {
 		await new Locker(testbed, 10, 1, 'exclude', 'authorVerificationRequested', 'verify').run();
 		expect(issue?.issue?.locked).to.be.true;
 	});
+
+	it('does not lock pull requests if the type is set to "issue"', async () => {
+		const issue: TestbedIssueConstructorArgs = {
+			issue: {
+				number: 1,
+				open: false,
+				locked: false,
+			},
+			labels: [],
+		};
+
+		const pr: TestbedIssueConstructorArgs = {
+			issue: {
+				number: 2,
+				open: false,
+				locked: false,
+				isPr: true,
+			},
+			labels: [],
+		};
+
+		const queryRunner = async function* (): AsyncIterableIterator<TestbedIssueConstructorArgs[]> {
+			yield [issue, pr];
+		};
+
+		const testbed = new Testbed({ queryRunner });
+		expect(issue?.issue?.locked).to.be.false;
+		expect(pr?.issue?.locked).to.be.false;
+
+		await new Locker(testbed, 10, 1, undefined, undefined, undefined, 'issue').run();
+		expect(issue?.issue?.locked).to.be.true;
+		expect(pr?.issue?.locked).to.be.false;
+	});
+
+	it('does not lock issues if the type is set to "pr"', async () => {
+		const issue: TestbedIssueConstructorArgs = {
+			issue: {
+				number: 1,
+				open: false,
+				locked: false,
+			},
+			labels: [],
+		};
+
+		const pr: TestbedIssueConstructorArgs = {
+			issue: {
+				number: 2,
+				open: false,
+				locked: false,
+				isPr: true,
+			},
+			labels: [],
+		};
+
+		const queryRunner = async function* (): AsyncIterableIterator<TestbedIssueConstructorArgs[]> {
+			yield [issue, pr];
+		};
+
+		const testbed = new Testbed({ queryRunner });
+		expect(issue?.issue?.locked).to.be.false;
+		expect(pr?.issue?.locked).to.be.false;
+
+		await new Locker(testbed, 10, 1, undefined, undefined, undefined, 'pr').run();
+		expect(issue?.issue?.locked).to.be.false;
+		expect(pr?.issue?.locked).to.be.true;
+	});
 });

--- a/locker/Locker.ts
+++ b/locker/Locker.ts
@@ -14,6 +14,7 @@ export class Locker {
 		private label?: string,
 		private ignoreLabelUntil?: string,
 		private labelUntil?: string,
+		private typeIs?: string,
 	) {}
 
 	async run() {
@@ -22,7 +23,8 @@ export class Locker {
 
 		const query =
 			`closed:<${closedTimestamp} updated:<${updatedTimestamp} is:unlocked` +
-			(this.label ? ` -label:${this.label}` : '');
+			(this.label ? ` -label:${this.label}` : '') +
+			(this.typeIs ? ` is:${this.typeIs}` : '');
 
 		for await (const page of this.github.query({ q: query })) {
 			await Promise.all(
@@ -32,7 +34,10 @@ export class Locker {
 					if (
 						!hydrated.locked &&
 						hydrated.open === false &&
-						(!this.label || !hydrated.labels.includes(this.label))
+						(!this.label || !hydrated.labels.includes(this.label)) &&
+						(!this.typeIs ||
+							(this.typeIs == 'issue' && !hydrated.isPr) ||
+							(this.typeIs == 'pr' && hydrated.isPr))
 						// TODO: Verify closed and updated timestamps
 					) {
 						const skipDueToIgnoreLabel =

--- a/locker/action.yml
+++ b/locker/action.yml
@@ -16,6 +16,8 @@ inputs:
     description: items with this label will not be automatically locked, until they also have the until label
   labelUntil:
     description: items with this will not automatically locked, even if they have the ignoreLabelUntil label
+  typeIs:
+    description: either 'issue' or 'pr' to limit the query to only those types
 runs:
   using: 'node16'
   main: 'index.js'

--- a/locker/index.js
+++ b/locker/index.js
@@ -13,7 +13,7 @@ class LockerAction extends Action_1.Action {
         this.id = 'Locker';
     }
     async onTriggered(github) {
-        await new Locker_1.Locker(github, +(0, utils_1.getRequiredInput)('daysSinceClose'), +(0, utils_1.getRequiredInput)('daysSinceUpdate'), (0, utils_1.getInput)('ignoredLabel') || undefined, (0, utils_1.getInput)('ignoreLabelUntil') || undefined, (0, utils_1.getInput)('labelUntil') || undefined).run();
+        await new Locker_1.Locker(github, +(0, utils_1.getRequiredInput)('daysSinceClose'), +(0, utils_1.getRequiredInput)('daysSinceUpdate'), (0, utils_1.getInput)('ignoredLabel') || undefined, (0, utils_1.getInput)('ignoreLabelUntil') || undefined, (0, utils_1.getInput)('labelUntil') || undefined, (0, utils_1.getInput)('typeIs') || undefined).run();
     }
 }
 new LockerAction().run(); // eslint-disable-line

--- a/locker/index.ts
+++ b/locker/index.ts
@@ -19,6 +19,7 @@ class LockerAction extends Action {
 			getInput('ignoredLabel') || undefined,
 			getInput('ignoreLabelUntil') || undefined,
 			getInput('labelUntil') || undefined,
+			getInput('typeIs') || undefined,
 		).run();
 	}
 }


### PR DESCRIPTION
We are adopting the Locker action in some of the dotnet repositories. In some repos though, we only want to lock issues and not PRs. This adds a new config setting to the locker action for `typeIs` that can be either `issue` or `pr`.

In addition to the new unit tests, this has been tested and validated against one our of repositories by installing the action from the branch of my fork, with configurations if `typeIs: issue`, `typeIs: pr`, and omitting the `typeIs` input.