### PR TITLE
Bump from Node 16 to Node 20 (Node 16 is out of support)

### DIFF
--- a/author-verified/action.yml
+++ b/author-verified/action.yml
@@ -17,5 +17,5 @@ inputs:
     description: Label added by issue fixer to signal that the author can verify the issue
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/blob-storage-test/action.yml
+++ b/blob-storage-test/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Azure blob storage connection string
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/build-chat/action.yml
+++ b/build-chat/action.yml
@@ -25,5 +25,5 @@ inputs:
     description: 'Which channel to send log messages to. Defaults to none.'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/classifier-deep/apply/apply-labels/action.yml
+++ b/classifier-deep/apply/apply-labels/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: "Pipe (|) separated list of labels such that the bot should act even if those labels are already present (use for bot-applied labels/etc.)"
     default: ''
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/classifier-deep/apply/fetch-sources/action.yml
+++ b/classifier-deep/apply/fetch-sources/action.yml
@@ -22,5 +22,5 @@ inputs:
   appInsightsKey:
     description: Key for Azure App Insights to monitor application health
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/classifier-deep/monitor/action.yml
+++ b/classifier-deep/monitor/action.yml
@@ -10,5 +10,5 @@ inputs:
   appInsightsKey:
     description: Key for Azure App Insights to monitor application health
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/classifier-deep/train/fetch-issues/action.yml
+++ b/classifier-deep/train/fetch-issues/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: Access string for blob storage account
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/classifier/train/fetch-issues/action.yml
+++ b/classifier/train/fetch-issues/action.yml
@@ -9,5 +9,5 @@ inputs:
   assignees:
     description: Pipe-seperated list of assignees to classify
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/classifier/train/upload-models/action.yml
+++ b/classifier/train/upload-models/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: Access string for blob storage account
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/code-review-chat/action.yml
+++ b/code-review-chat/action.yml
@@ -34,5 +34,5 @@ inputs:
     description: 'Repository name - used in webhooks'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/commands/action.yml
+++ b/commands/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Name of .json file (no extension) in .github/ directory of repo holding configuration for this action
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/copycat/action.yml
+++ b/copycat/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: name of the destination repo (the vscode part of microsoft/vscode)
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/english-please/action.yml
+++ b/english-please/action.yml
@@ -19,5 +19,5 @@ inputs:
     description: API key for the text translator cognitive service to use when detecting issue language and responding to the issue author in their language
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/feature-request/action.yml
+++ b/feature-request/action.yml
@@ -48,5 +48,5 @@ inputs:
     description: Delay between adding a feature request label and assigning the issue to candidate milestone
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/latest-release-monitor/action.yml
+++ b/latest-release-monitor/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Azure blob storage connection string
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/locker/action.yml
+++ b/locker/action.yml
@@ -19,5 +19,5 @@ inputs:
   typeIs:
     description: either 'issue' or 'pr' to limit the query to only those types
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/needs-more-info-closer/action.yml
+++ b/needs-more-info-closer/action.yml
@@ -20,5 +20,5 @@ inputs:
   pingComment:
     description: Comment to add when pinging assignee. ${assignee} and ${author} are replaced.
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/new-release/action.yml
+++ b/new-release/action.yml
@@ -19,5 +19,5 @@ inputs:
   oldVersionMessage:
     description: comment to post when an issue version is not the latest version. The token "{currentVersion}" will be replaced with the latest release version
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/python-issue-labels/action.yml
+++ b/python-issue-labels/action.yml
@@ -11,5 +11,5 @@ inputs:
     default: '["karrtikr","karthiknadig","paulacamargo25","eleanorjboyd"]'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/python-triage-info-needed/action.yml
+++ b/python-triage-info-needed/action.yml
@@ -19,5 +19,5 @@ inputs:
     default: '["\\?", "please", "kindly", "let me know", "try", "can you", "could you", "would you", "may I", "provide", "let us know", "tell me", "give me", "send me", "what", "when", "where", "why", "how"]'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/regex-labeler/action.yml
+++ b/regex-labeler/action.yml
@@ -13,5 +13,5 @@ inputs:
   label:
     description: Label to apply to isses that don't fit the criteria
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/release-pipeline/action.yml
+++ b/release-pipeline/action.yml
@@ -11,5 +11,5 @@ inputs:
     description: Label for issues that have been released to Insiders
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/review-reminder/action.yml
+++ b/review-reminder/action.yml
@@ -10,5 +10,5 @@ inputs:
     description: Slack token.
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/tag-alert/action.yml
+++ b/tag-alert/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Name of the tag to alert on
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/test-plan-item-validator/action.yml
+++ b/test-plan-item-validator/action.yml
@@ -18,5 +18,5 @@ inputs:
     description: Comment to post to invalid test plan items
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/topic-subscribe/action.yml
+++ b/topic-subscribe/action.yml
@@ -8,5 +8,5 @@ inputs:
     description: Name of .json file (no extension) in .github/ directory of repo holding configuration for this action
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'


### PR DESCRIPTION
Fixes #207

Bumps to Node 20 across all actions. The last time this was bumped was in https://github.com/microsoft/vscode-github-triage-actions/commit/cd16cd2aad6ba2da74bb6c6f7293adddd579a90e, when all actions were bumped from Node 12 to Node 16.

A smoke test was conducted in [jeffhandley/github-actions-testing](https://github.com/jeffhandley/github-actions-testing/actions/workflows/locker.yml) where the following runs were conducted:

1. [8445586442](https://github.com/jeffhandley/github-actions-testing/actions/runs/8445586442)
    - Using ref cd16cd2aad6ba2da74bb6c6f7293adddd579a90e, which is the SHA used by many of the [dotnet](https://github.com/dotnet) org repositories
    - This reproduced the GitHub warning
1. [8445600725](https://github.com/jeffhandley/github-actions-testing/actions/runs/8445600725)
    - Using ref 5b9ae07f2e85a0da788e905df009b15ce95cdcd8, which is the most recent SHA for the Locker action
    - This reproduced the GitHub warning
1. [8445658740](https://github.com/jeffhandley/github-actions-testing/actions/runs/8445658740)
    - Using ref 9a1c503bb5a3f9f89134b291591a1cc089ebb6c3, which is the commit into [jeffhandley/github-triage-actions](https://github.com/jeffhandley/github-triage-actions/commit/9a1c503bb5a3f9f89134b291591a1cc089ebb6c3) included in this PR
    - **The GitHub warning went away, and the run still succeeded**

Kudos to @russkie for reporting #207 and scouting this out.