### PR TITLE
[Issue Locker] Reduce # of parallel calls to 50 to avoid hitting secondary rate limits

### DIFF
--- a/api/api.ts
+++ b/api/api.ts
@@ -119,4 +119,5 @@ export interface Query {
 	q: string;
 	sort?: SortVar;
 	order?: SortOrder;
+	per_page?: number;
 }

--- a/api/octokit.ts
+++ b/api/octokit.ts
@@ -43,11 +43,11 @@ export class OctoKit implements GitHub {
 	// TODO: just iterate over the issues in a page here instead of making caller do it
 	async *query(query: Query): AsyncIterableIterator<GitHubIssue[]> {
 		const q = query.q + ` repo:${this.params.owner}/${this.params.repo}`;
-
+		const per_page = query.per_page ?? 100;
 		const options = {
 			...query,
 			q,
-			per_page: 100,
+			per_page,
 			headers: { Accept: 'application/vnd.github.squirrel-girl-preview+json' },
 		};
 

--- a/locker/Locker.ts
+++ b/locker/Locker.ts
@@ -29,7 +29,7 @@ export class Locker {
 			(milestones.length > 0 ? milestonesQuery : '') +
 			(this.typeIs ? ` is:${this.typeIs}` : '');
 
-		for await (const page of this.github.query({ q: query })) {
+		for await (const page of this.github.query({ q: query, per_page: 50 })) {
 			await Promise.all(
 				page.map(async (issue) => {
 					const hydrated = await issue.getIssue();


### PR DESCRIPTION
Issue locker runs have been failing for a few months now (~6months) and we have a lot of issues and pr that need to be addressed (https://github.com/microsoft/vscode/actions/runs/9409153996/job/25918527009). Trying to lock 100 issues in parallel causes us to hit the secondary rate limit. Reducing the per page count to 50 for now. Once we're all caught up, I'll probably increase this to 75.