### PR TITLE
Fix copycat input names

### DIFF
--- a/copycat/action.yml
+++ b/copycat/action.yml
@@ -4,10 +4,10 @@ inputs:
   token:
     description: GitHub token with issue, comment, and label read/write permissions to both repos
     default: ${{ github.token }}
-  owner:
+  destinationOwner:
     description: account/organization that owns the destination repo (the microsoft part of microsoft/vscode)
     required: true
-  repo:
+  destinationRepo:
     description: name of the destination repo (the vscode part of microsoft/vscode)
     required: true
 runs:

--- a/copycat/index.js
+++ b/copycat/index.js
@@ -4,16 +4,16 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 Object.defineProperty(exports, "__esModule", { value: true });
+const Action_1 = require("../common/Action");
 const utils_1 = require("../common/utils");
 const CopyCat_1 = require("./CopyCat");
-const Action_1 = require("../common/Action");
 class CopyCatAction extends Action_1.Action {
     constructor() {
         super(...arguments);
         this.id = 'CopyCat';
     }
     async onOpened(issue) {
-        await new CopyCat_1.CopyCat(issue, (0, utils_1.getRequiredInput)('owner'), (0, utils_1.getRequiredInput)('repo')).run();
+        await new CopyCat_1.CopyCat(issue, (0, utils_1.getRequiredInput)('destinationOwner'), (0, utils_1.getRequiredInput)('destinationRepo')).run();
     }
 }
 new CopyCatAction().run(); // eslint-disable-line

--- a/copycat/index.ts
+++ b/copycat/index.ts
@@ -4,15 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { OctoKitIssue } from '../api/octokit';
+import { Action } from '../common/Action';
 import { getRequiredInput } from '../common/utils';
 import { CopyCat } from './CopyCat';
-import { Action } from '../common/Action';
 
 class CopyCatAction extends Action {
 	id = 'CopyCat';
 
 	async onOpened(issue: OctoKitIssue) {
-		await new CopyCat(issue, getRequiredInput('owner'), getRequiredInput('repo')).run();
+		await new CopyCat(
+			issue,
+			getRequiredInput('destinationOwner'),
+			getRequiredInput('destinationRepo'),
+		).run();
 	}
 }
 


### PR DESCRIPTION
Fix input variables names to prevent clashing with "owner" and "repo" inputs.