### PR TITLE
Remove "From Fork" prefix

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -174,8 +174,7 @@ class CodeReviewChat extends Chatter {
         const githubUrl = `${pr.url}/files`;
         const vscodeDevUrl = pr.url.replace('https://', 'https://insiders.vscode.dev/');
         const externalPrefix = this._externalContributorPR ? '⚠️[EXTERNAL]⚠️ ' : '';
-        const forkPrefix = pr.fork ? `(From Fork: ${pr.headLabel}) ` : '';
-        const message = `${externalPrefix}${forkPrefix}*${cleanTitle}* by _${pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`;
+        const message = `${externalPrefix}*${cleanTitle}* by _${pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`;
         return message;
     }
     async run() {

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -242,8 +242,7 @@ export class CodeReviewChat extends Chatter {
 		const vscodeDevUrl = pr.url.replace('https://', 'https://insiders.vscode.dev/');
 
 		const externalPrefix = this._externalContributorPR ? '⚠️[EXTERNAL]⚠️ ' : '';
-		const forkPrefix = pr.fork ? `(From Fork: ${pr.headLabel}) ` : '';
-		const message = `${externalPrefix}${forkPrefix}*${cleanTitle}* by _${pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`;
+		const message = `${externalPrefix}*${cleanTitle}* by _${pr.owner}_${repoMessage} \`${diffMessage}\` <${githubUrl}|Review (GH)> | <${vscodeDevUrl}|Review (VSCode)>`;
 		return message;
 	}
 


### PR DESCRIPTION
Fixes: 
https://github.com/microsoft/vscode-engineering/issues/708
Removing this entirely since external pr prefixes have '⚠️' to call attention to them.