### PR TITLE
Update TestPlanItemValidator Inputs

### DIFF
--- a/common/Action.ts
+++ b/common/Action.ts
@@ -51,7 +51,7 @@ export abstract class Action {
 	}
 
 	getIssueNumber() {
-		const issueNumber = +(getInput('issue') ?? 0);
+		const issueNumber = +(getInput('issue_number') ?? 0);
 		return (
 			(issueNumber > 0 ? issueNumber : undefined) ??
 			context.issue?.number ??

--- a/test-plan-item-validator/action.yml
+++ b/test-plan-item-validator/action.yml
@@ -1,24 +1,27 @@
 name: 'Test Plan Item Validator'
 description: Tag issues that don't contain important info
 inputs:
+  token:
+    description: 'GitHub token with issue, comment, and label read/write permissions'
+    default: ${{ github.token }}
   app_id:
     description: GitHub App ID
-    required: true
+    required: false
   app_installation_id:
     description: GitHub App Installation ID
-    required: true
+    required: false
   app_private_key:
     description: GitHub App Private Key
-    required: true
+    required: false
   owner:
     description: Repository owner
-    required: true
+    required: false
   repo:
     description: Repository name
-    required: true
+    required: false
   issue_number:
     description: Issue number
-    required: true
+    required: false
   label:
     description: The label that signifies an item is a testplan item and should be checked
     required: true

--- a/test-plan-item-validator/action.yml
+++ b/test-plan-item-validator/action.yml
@@ -1,9 +1,24 @@
 name: 'Test Plan Item Validator'
 description: Tag issues that don't contain important info
 inputs:
-  token:
-    description: 'GitHub token with issue, comment, and label read/write permissions'
-    default: ${{ github.token }}
+  app_id:
+    description: GitHub App ID
+    required: true
+  app_installation_id:
+    description: GitHub App Installation ID
+    required: true
+  app_private_key:
+    description: GitHub App Private Key
+    required: true
+  owner:
+    description: Repository owner
+    required: true
+  repo:
+    description: Repository name
+    required: true
+  issue_number:
+    description: Issue number
+    required: true
   label:
     description: The label that signifies an item is a testplan item and should be checked
     required: true


### PR DESCRIPTION
Keeping the triage bot token around till we migrate the vscode repo test-plan-item-validator workflow over also.