### PR TITLE
Fix repo and owner for dispatch events

### DIFF
--- a/latest-release-monitor/index.js
+++ b/latest-release-monitor/index.js
@@ -25,8 +25,8 @@ class LatestReleaseMonitor extends Action_1.Action {
         const latest = (_a = (await (0, utils_1.loadLatestRelease)(quality))) === null || _a === void 0 ? void 0 : _a.version;
         if (latest && latest !== lastKnown) {
             (0, utils_1.safeLog)('found a new release of', quality);
-            const owner = this.repoOwner;
-            const repo = this.repoName;
+            const owner = 'microsoft';
+            const repo = 'vscode-engineering';
             const token = await this.getToken();
             await (0, blobStorage_1.uploadBlobText)('latest-' + quality, latest, 'latest-releases');
             await new octokit_1.OctoKit(token, { owner, repo }).dispatch('released-' + quality);

--- a/latest-release-monitor/index.ts
+++ b/latest-release-monitor/index.ts
@@ -22,8 +22,8 @@ class LatestReleaseMonitor extends Action {
 		const latest = (await loadLatestRelease(quality))?.version;
 		if (latest && latest !== lastKnown) {
 			safeLog('found a new release of', quality);
-			const owner = this.repoOwner;
-			const repo = this.repoName;
+			const owner = 'microsoft';
+			const repo = 'vscode-engineering';
 			const token = await this.getToken();
 			await uploadBlobText('latest-' + quality, latest, 'latest-releases');
 			await new OctoKit(token, { owner, repo }).dispatch('released-' + quality);


### PR DESCRIPTION
All our workflows run in the `vscode-engineering` repo and the dispatch events should be triggered there. This is ok to hardcode since we'll move all this as a part of: https://github.com/microsoft/vscode-engineering/issues/722