### PR TITLE
Fix repo list iteration during processing

### DIFF
--- a/review-reminder/ReviewReminder.js
+++ b/review-reminder/ReviewReminder.js
@@ -62,9 +62,14 @@ class ReviewReminder {
         const it = octokit.paginate.iterator(octokit.rest.apps.listReposAccessibleToInstallation, {
             per_page: 100,
         });
-        for await (const response of it) {
-            console.log(`Processing GitHubApp installation ${response.data}`);
-            for (const repository of response.data.repositories) {
+        for await (const { data: repositories } of it) {
+            const repos = Array.isArray(repositories)
+                ? repositories
+                : [];
+            if (repositories.repositories) {
+                repos.push(...repositories.repositories);
+            }
+            for (const repository of repos) {
                 if (repository.archived) {
                     continue;
                 }

--- a/review-reminder/ReviewReminder.ts
+++ b/review-reminder/ReviewReminder.ts
@@ -95,9 +95,16 @@ export class ReviewReminder {
 			per_page: 100,
 		});
 
-		for await (const response of it) {
-			console.log(`Processing GitHubApp installation ${response.data}`);
-			for (const repository of response.data.repositories) {
+		for await (const { data: repositories } of it) {
+			const repos = Array.isArray(repositories)
+				? (repositories as typeof repositories['repositories'])
+				: [];
+
+			if (repositories.repositories) {
+				repos.push(...repositories.repositories);
+			}
+
+			for (const repository of repos) {
 				if (repository.archived) {
 					continue;
 				}


### PR DESCRIPTION
Kept running into:
`TypeError response.data.repositories is not iterable` while running this workflow. 

Affected by https://github.com/octokit/plugin-paginate-rest.js/issues/350.

Successful run: 
https://github.com/microsoft/vscode-engineering/actions/runs/11144871175/job/30973128773