### PR TITLE
Add safe logging for detected language in LanguageSpecificLabeler

### DIFF
--- a/english-please/EnglishPlease.js
+++ b/english-please/EnglishPlease.js
@@ -96,6 +96,7 @@ class LanguageSpecificLabeler {
             }
         }
         const language = (_a = (await this.detectLanguage(translationChunk))) === null || _a === void 0 ? void 0 : _a.toLowerCase();
+        (0, utils_1.safeLog)('Detected language:', language !== null && language !== void 0 ? language : 'undefined');
         if (!language || language === 'en') {
             const languagelabel = issue.labels.find((label) => label.startsWith(this.translatorRequestedLabelPrefix));
             if (languagelabel)

--- a/english-please/EnglishPlease.ts
+++ b/english-please/EnglishPlease.ts
@@ -111,7 +111,7 @@ export class LanguageSpecificLabeler {
 		}
 
 		const language = (await this.detectLanguage(translationChunk))?.toLowerCase();
-
+		safeLog('Detected language:', language ?? 'undefined');
 		if (!language || language === 'en') {
 			const languagelabel = issue.labels.find((label) =>
 				label.startsWith(this.translatorRequestedLabelPrefix),


### PR DESCRIPTION
Debugging *english-please workflow -> bot removed this label sometimes. 
Example:
https://github.com/microsoft/vscode-copilot-release/issues/2036
https://github.com/microsoft/vscode-remote-release/issues/9287