### PR TITLE
Improve error handling and retry logic for authentication token retrieval; refactor end game check in CodeReviewChat

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -206,7 +206,13 @@ class CodeReviewChat extends Chatter {
             (0, utils_1.safeLog)('PR is on a non-main or release branch, ignoring');
             return;
         }
-        const isEndGame = (_a = (await (0, utils_1.isInsiderFrozen)())) !== null && _a !== void 0 ? _a : false;
+        let isEndGame = false;
+        try {
+            isEndGame = (_a = (await (0, utils_1.isInsiderFrozen)())) !== null && _a !== void 0 ? _a : false;
+        }
+        catch (error) {
+            (0, utils_1.safeLog)(`Error determining if insider is frozen: ${error.message}`);
+        }
         // This is an external PR which already received one review and is just awaiting a second
         const data = await this.issue.getIssue();
         if (this._externalContributorPR) {

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -81,7 +81,7 @@ export function createPRObject(pullRequestFromApi: any): PR {
 }
 
 class Chatter {
-	constructor(protected slackToken: string, protected notificationChannelID: string) { }
+	constructor(protected slackToken: string, protected notificationChannelID: string) {}
 
 	async getChat(): Promise<{ client: WebClient; channel: string }> {
 		const web = new WebClient(this.slackToken);
@@ -282,7 +282,13 @@ export class CodeReviewChat extends Chatter {
 			return;
 		}
 
-		const isEndGame = (await isInsiderFrozen()) ?? false;
+		let isEndGame = false;
+		try {
+			isEndGame = (await isInsiderFrozen()) ?? false;
+		} catch (error) {
+			safeLog(`Error determining if insider is frozen: ${(error as Error).message}`);
+		}
+
 		// This is an external PR which already received one review and is just awaiting a second
 		const data = await this.issue.getIssue();
 		if (this._externalContributorPR) {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode-engineering/issues/957

Will consider pulling in `cockatiel` if we encounter 504 errors in more places. For now, keeping it simple since most of the retriable failures are in this piece of code.