### PR TITLE
Enhance fork detection logic in PR object creation to ensure accurate identification of forks

### DIFF
--- a/code-review-chat/CodeReviewChat.js
+++ b/code-review-chat/CodeReviewChat.js
@@ -22,7 +22,9 @@ function createPRObject(pullRequestFromApi) {
         headBranchName: (_b = pullRequestFromApi.head.ref) !== null && _b !== void 0 ? _b : '',
         title: pullRequestFromApi.title,
         headLabel: ((_c = pullRequestFromApi.head.repo) === null || _c === void 0 ? void 0 : _c.full_name) || '',
-        fork: ((_d = pullRequestFromApi.head.repo) === null || _d === void 0 ? void 0 : _d.fork) || false,
+        fork: (((_d = pullRequestFromApi.head.repo) === null || _d === void 0 ? void 0 : _d.fork) &&
+            pullRequestFromApi.head.repo.full_name != pullRequestFromApi.base.repo.full_name) ||
+            false,
     };
     return pr;
 }

--- a/code-review-chat/CodeReviewChat.ts
+++ b/code-review-chat/CodeReviewChat.ts
@@ -75,7 +75,10 @@ export function createPRObject(pullRequestFromApi: any): PR {
 		headBranchName: pullRequestFromApi.head.ref ?? '',
 		title: pullRequestFromApi.title,
 		headLabel: pullRequestFromApi.head.repo?.full_name || '',
-		fork: pullRequestFromApi.head.repo?.fork || false,
+		fork:
+			(pullRequestFromApi.head.repo?.fork &&
+				pullRequestFromApi.head.repo.full_name != pullRequestFromApi.base.repo.full_name) ||
+			false,
 	};
 	return pr;
 }


### PR DESCRIPTION
`vscode-python` is a fork. So we end up showing the below comment on prs from branches
https://github.com/microsoft/vscode-python/pull/24794#issuecomment-2641091957

Added an extra check to account for cases like this. 