### PR TITLE
    Add support for leaving comments in english if language is incorrectly detected

### DIFF
--- a/english-please/EnglishPlease.js
+++ b/english-please/EnglishPlease.js
@@ -29,13 +29,14 @@ class EnglishPleaseLabler {
 }
 exports.EnglishPleaseLabler = EnglishPleaseLabler;
 class LanguageSpecificLabeler {
-    constructor(issue, translatorRequestedLabelPrefix, translatorRequestedLabelColor, englishPleaseLabel, needsMoreInfoLabel, cognitiveServicesAPIKey) {
+    constructor(issue, translatorRequestedLabelPrefix, translatorRequestedLabelColor, englishPleaseLabel, needsMoreInfoLabel, cognitiveServicesAPIKey, shouldLeaveEnComment) {
         this.issue = issue;
         this.translatorRequestedLabelPrefix = translatorRequestedLabelPrefix;
         this.translatorRequestedLabelColor = translatorRequestedLabelColor;
         this.englishPleaseLabel = englishPleaseLabel;
         this.needsMoreInfoLabel = needsMoreInfoLabel;
         this.cognitiveServicesAPIKey = cognitiveServicesAPIKey;
+        this.shouldLeaveEnComment = shouldLeaveEnComment;
     }
     async detectLanguage(chunk) {
         var _a, _b;
@@ -107,6 +108,9 @@ class LanguageSpecificLabeler {
                 await this.issue.removeLabel(languagelabel);
             await this.issue.removeLabel(this.englishPleaseLabel);
             await this.issue.removeLabel(this.needsMoreInfoLabel);
+            if (this.shouldLeaveEnComment) {
+                await this.issue.postComment(`${translation_data_json_1.baseString}\n<!-- translation_requested_comment -->`);
+            }
         }
         else if (language) {
             const label = this.translatorRequestedLabelPrefix + commonNames[language];

--- a/english-please/EnglishPlease.ts
+++ b/english-please/EnglishPlease.ts
@@ -42,6 +42,7 @@ export class LanguageSpecificLabeler {
 		private englishPleaseLabel: string,
 		private needsMoreInfoLabel: string,
 		private cognitiveServicesAPIKey: string,
+		private shouldLeaveEnComment: boolean,
 	) {}
 
 	private async detectLanguage(chunk: string): Promise<string | undefined> {
@@ -123,6 +124,9 @@ export class LanguageSpecificLabeler {
 			if (languagelabel) await this.issue.removeLabel(languagelabel);
 			await this.issue.removeLabel(this.englishPleaseLabel);
 			await this.issue.removeLabel(this.needsMoreInfoLabel);
+			if (this.shouldLeaveEnComment) {
+				await this.issue.postComment(`${baseString}\n<!-- translation_requested_comment -->`);
+			}
 		} else if (language) {
 			const label = this.translatorRequestedLabelPrefix + commonNames[language];
 			if (!(await this.issue.repoHasLabel(label))) {

--- a/english-please/cli.js
+++ b/english-please/cli.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 const yargs = require("yargs");
-const EnglishPlease_1 = require("./EnglishPlease");
 const octokit_1 = require("../api/octokit");
+const EnglishPlease_1 = require("./EnglishPlease");
 const argv = yargs
     .option('token', {
     alias: 't',
@@ -40,7 +40,7 @@ const main = async () => {
     // Check if it's a promise
     const args = await argv;
     const [, owner, repo] = /(.*)\/(.*)/.exec(args.repo);
-    await new EnglishPlease_1.LanguageSpecificLabeler(new octokit_1.OctoKitIssue(args.token, { repo, owner }, { number: args.number }, { readonly: !args.write }), 'translation-required-', 'c29cff', '*english-please', 'info-needed', args.key).run();
+    await new EnglishPlease_1.LanguageSpecificLabeler(new octokit_1.OctoKitIssue(args.token, { repo, owner }, { number: args.number }, { readonly: !args.write }), 'translation-required-', 'c29cff', '*english-please', 'info-needed', args.key, false).run();
 };
 main().catch(console.error);
 //# sourceMappingURL=cli.js.map

--- a/english-please/cli.ts
+++ b/english-please/cli.ts
@@ -1,6 +1,6 @@
 import * as yargs from 'yargs';
-import { LanguageSpecificLabeler } from './EnglishPlease';
 import { OctoKitIssue } from '../api/octokit';
+import { LanguageSpecificLabeler } from './EnglishPlease';
 
 const argv = yargs
 	.option('token', {
@@ -48,6 +48,7 @@ const main = async () => {
 		'*english-please',
 		'info-needed',
 		args.key,
+		false,
 	).run();
 };
 

--- a/english-please/index.js
+++ b/english-please/index.js
@@ -16,15 +16,15 @@ class EnglishPlease extends Action_1.Action {
     async onOpened(issue) {
         await new EnglishPlease_1.EnglishPleaseLabler(issue, nonEnglishLabel).run();
     }
-    async doLanguageSpecific(issue) {
-        await new EnglishPlease_1.LanguageSpecificLabeler(issue, translatorRequestedLabelPrefix, translatorRequestedLabelColor, nonEnglishLabel, needsMoreInfoLabel, cognitiveServicesAPIKey).run();
+    async doLanguageSpecific(issue, shouldLeaveEnComment = false) {
+        await new EnglishPlease_1.LanguageSpecificLabeler(issue, translatorRequestedLabelPrefix, translatorRequestedLabelColor, nonEnglishLabel, needsMoreInfoLabel, cognitiveServicesAPIKey, shouldLeaveEnComment).run();
     }
     async onEdited(issue) {
         await this.doLanguageSpecific(issue);
     }
     async onLabeled(issue, label) {
         if (label == nonEnglishLabel)
-            await this.doLanguageSpecific(issue);
+            await this.doLanguageSpecific(issue, true /* shouldLeaveEnComment */);
     }
 }
 new EnglishPlease().run(); // eslint-disable-line

--- a/english-please/index.ts
+++ b/english-please/index.ts
@@ -16,7 +16,7 @@ class EnglishPlease extends Action {
 		await new EnglishPleaseLabler(issue, nonEnglishLabel).run();
 	}
 
-	async doLanguageSpecific(issue: OctoKitIssue) {
+	async doLanguageSpecific(issue: OctoKitIssue, shouldLeaveEnComment = false) {
 		await new LanguageSpecificLabeler(
 			issue,
 			translatorRequestedLabelPrefix,
@@ -24,6 +24,7 @@ class EnglishPlease extends Action {
 			nonEnglishLabel,
 			needsMoreInfoLabel,
 			cognitiveServicesAPIKey,
+			shouldLeaveEnComment,
 		).run();
 	}
 
@@ -31,8 +32,7 @@ class EnglishPlease extends Action {
 		await this.doLanguageSpecific(issue);
 	}
 	async onLabeled(issue: OctoKitIssue, label: string) {
-		if (label == nonEnglishLabel) await this.doLanguageSpecific(issue);
+		if (label == nonEnglishLabel) await this.doLanguageSpecific(issue, true /* shouldLeaveEnComment */);
 	}
 }
-
-new EnglishPlease().run() // eslint-disable-line
+new EnglishPlease().run(); // eslint-disable-line


### PR DESCRIPTION
🐛 *english-please worked for this one -> https://github.com/microsoft/vscode-copilot-release/issues/7171 . But then it didn’t work for this one today -> https://github.com/microsoft/vscode-copilot-release/issues/7232

---
The translator service returns ‘en’ as the only language when multiple languages are mixed. I tried adjusting the score, but that didn’t provide a definitive solution. Falling back to leaving english comment when the labelers adds `*english-please` comment.

---

Resources used: https://learn.microsoft.com/en-us/azure/ai-services/translator/text-translation/reference/v3/reference

